### PR TITLE
always use proxy function revert to default behaviour

### DIFF
--- a/src/lib/image.js
+++ b/src/lib/image.js
@@ -83,17 +83,18 @@ $builtinmodule = function (name) {
 
             var proxy = typeof(Sk.imageProxy) === "function"
                         ? Sk.imageProxy : function (str) {
-                            return Sk.imageProxy + "/" + str;
+                            url = document.createElement("a");
+                            url.href = ret;
+                            if (window.location.host !== url.host) {
+                              return Sk.imageProxy + "/" + str;
+                            } 
+                            return str;
                         };
 
             var url;
             var ret;
             ret = Sk.ffi.remapToJs(imageId);
-            url = document.createElement("a");
-            url.href = ret;
-            if (window.location.host !== url.host) {
-                ret = proxy(ret);
-            }
+            ret = proxy(ret);
             return ret;
         };
 
@@ -378,7 +379,7 @@ $builtinmodule = function (name) {
         });
 
         $loc.__str__ = new Sk.builtin.func(function (self) {
-            return "[" + self.red + "," + self.green + "," + self.blue + "]";
+            return Sk.ffi.remapToPy("[" + self.red + "," + self.green + "," + self.blue + "]");
         });
 
         //getColorTuple


### PR DESCRIPTION
The default behaviour only used the proxy when the image was on a different host. We always want to use the proxy function. As our assets have different names.

And fixes a little bug in the `__str__` of Pixel.