### PR TITLE
Removes setpixels call on fb device init.

### DIFF
--- a/src/lib/sense_hat/hat.py
+++ b/src/lib/sense_hat/hat.py
@@ -184,7 +184,6 @@ class FBDevice:
         self.gamma = [0]*32
 
         _ish.init()
-        _ish.setpixels(self.data)
 
     def setpixel(self, index, value):
         _ish.setpixel(index, value)


### PR DESCRIPTION
I believe this fixes the issue of reading the correct value of pixels over multiple runs when the pixels aren't cleared.

Simple example. Run the program below. Comment out the `sense.set_pixel` line and run again. The `sense.get_pixel` value should still be `[248, 252, 248]`.

```python
from sense_hat import SenseHat
import time

sense = SenseHat()

sense.set_pixel(0, 0, 255, 255, 255)
print(sense.get_pixel(0, 0))
```

@waywaaard Any reasons you know of that this isn't ok?