### PR TITLE
Fixes Sk.killableWhile performance issues

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -1093,7 +1093,7 @@ Compiler.prototype.cwhile = function (s) {
         this.setBlock(body);
 
         if ((Sk.debugging || Sk.killableWhile) && this.u.canSuspend) {
-            var suspType = 'Sk.delay';
+            var suspType = 'Sk.nextTick';
             var debugBlock = this.newBlock("debug breakpoint for line "+s.lineno);
             out("if (Sk.breakpoints('"+this.filename+"',"+s.lineno+","+s.col_offset+")) {",
                 "var $susp = $saveSuspension({data: {type: '"+suspType+"'}, resume: function() {}}, '"+this.filename+"',"+s.lineno+","+s.col_offset+");",
@@ -1162,7 +1162,7 @@ Compiler.prototype.cfor = function (s) {
     target = this.vexpr(s.target, nexti);
 
     if ((Sk.debugging || Sk.killableFor) && this.u.canSuspend) {
-        var suspType = 'Sk.delay';
+        var suspType = 'Sk.nextTick';
         var debugBlock = this.newBlock("debug breakpoint for line "+s.lineno);
         out("if (Sk.breakpoints('"+this.filename+"',"+s.lineno+","+s.col_offset+")) {",
             "var $susp = $saveSuspension({data: {type: '"+suspType+"'}, resume: function() {}}, '"+this.filename+"',"+s.lineno+","+s.col_offset+");",


### PR DESCRIPTION
This PR replaces the window.timeout approach with a postMessage approach. My test have shown, that all is working.

The patch does not work on the normal run and only in the browser. I had to guard the window.postMessage calls in order to make closure and v8 happy.

@albertjan Should we put the checks with Sk.browser?