### PR TITLE
Timestamp fix

### DIFF
--- a/src/lib/_internal_sense_hat.js
+++ b/src/lib/_internal_sense_hat.js
@@ -412,7 +412,7 @@ var $builtinmodule = function (name) {
             promise: new Promise(function (resolve, reject) {
                 // Read from internal eventQueue
                 if (Sk.sense_hat.sensestick._eventQueue.length > 0) {
-                    inputEvent = Sk.sense_hat.sensestick._eventQueue.pop();
+                    inputEvent = Sk.sense_hat.sensestick._eventQueue.shift();
                     resolve();
                 } else {
                     // add eventlistener
@@ -422,7 +422,7 @@ var $builtinmodule = function (name) {
                             reject('KeyboardInterrupt');
                         }
 
-                        inputEvent = inputEvent = Sk.sense_hat.sensestick._eventQueue.pop();
+                        inputEvent = inputEvent = Sk.sense_hat.sensestick._eventQueue.shift();
                         resolve();
                     });
                 }

--- a/src/lib/sense_hat/stick.py
+++ b/src/lib/sense_hat/stick.py
@@ -198,7 +198,9 @@ class SenseStick(object):
             event = self._read()
             if event:
                 result.append(event)
-        return result
+        # Make sure returned events are sorted by timestamp
+        results = sorted(result, key=lambda x: x.timestamp)
+        return results
 
     @property
     def direction_up(self):

--- a/src/lib/sense_hat/stick.py
+++ b/src/lib/sense_hat/stick.py
@@ -198,9 +198,7 @@ class SenseStick(object):
             event = self._read()
             if event:
                 result.append(event)
-        # Make sure returned events are sorted by timestamp
-        results = sorted(result, key=lambda x: x.timestamp)
-        return results
+        return result
 
     @property
     def direction_up(self):


### PR DESCRIPTION
Should fix  https://github.com/astro-pi/beta-testing/issues/29

Test code will print *** if timestamps are out of order:

```python
#!/usr/bin/python3
import time
import sense_hat
sense = sense_hat.SenseHat()

while True:
    time.sleep(.1)
    prev = time.time()
    for event in sense.stick.get_events():
        print("new loop")
        end = ""
        if prev > event.timestamp:
          end = "***"
        print(event.timestamp, event.action, end)
        prev = event.timestamp
```

Verified that this still works fine with the callback style joystick API

Not sure what those stray commits are doing in there but they don't show up in the diff