### PR TITLE
Import fu

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -3,84 +3,6 @@ var out;
 
 Sk.gensymcount = 0;
 
-var reservedWords_ = {
-    "abstract": true,
-    "as": true,
-    "boolean": true,
-    "break": true,
-    "byte": true,
-    "case": true,
-    "catch": true,
-    "char": true,
-    "class": true,
-    "continue": true,
-    "const": true,
-    "debugger": true,
-    "default": true,
-    "delete": true,
-    "do": true,
-    "double": true,
-    "else": true,
-    "enum": true,
-    "export": true,
-    "extends": true,
-    "false": true,
-    "final": true,
-    "finally": true,
-    "float": true,
-    "for": true,
-    "function": true,
-    "goto": true,
-    "if": true,
-    "implements": true,
-    "import": true,
-    "in": true,
-    "instanceof": true,
-    "int": true,
-    "interface": true,
-    "is": true,
-    "long": true,
-    "namespace": true,
-    "native": true,
-    "new": true,
-    "null": true,
-    "package": true,
-    "private": true,
-    "protected": true,
-    "public": true,
-    "return": true,
-    "short": true,
-    "static": true,
-    "super": false,
-    "switch": true,
-    "synchronized": true,
-    "this": true,
-    "throw": true,
-    "throws": true,
-    "transient": true,
-    "true": true,
-    "try": true,
-    "typeof": true,
-    "use": true,
-    "var": true,
-    "void": true,
-    "volatile": true,
-    "while": true,
-    "with": true
-};
-
-/**
- * Fix reserved words
- * 
- * @param {string} name
- */
-Sk.fixReservedWords = function fixReservedWords(name) {
-    if (reservedWords_[name] !== true) {
-        return name;
-    }
-    return name + "_$rw$";
-}
-
 /**
  * @constructor
  * @param {string} filename
@@ -199,6 +121,84 @@ Compiler.prototype.gensym = function (hint) {
 Compiler.prototype.niceName = function (roughName) {
     return this.gensym(roughName.replace("<", "").replace(">", "").replace(" ", "_"));
 };
+
+var reservedWords_ = {
+    "abstract": true,
+    "as": true,
+    "boolean": true,
+    "break": true,
+    "byte": true,
+    "case": true,
+    "catch": true,
+    "char": true,
+    "class": true,
+    "continue": true,
+    "const": true,
+    "debugger": true,
+    "default": true,
+    "delete": true,
+    "do": true,
+    "double": true,
+    "else": true,
+    "enum": true,
+    "export": true,
+    "extends": true,
+    "false": true,
+    "final": true,
+    "finally": true,
+    "float": true,
+    "for": true,
+    "function": true,
+    "goto": true,
+    "if": true,
+    "implements": true,
+    "import": true,
+    "in": true,
+    "instanceof": true,
+    "int": true,
+    "interface": true,
+    "is": true,
+    "long": true,
+    "namespace": true,
+    "native": true,
+    "new": true,
+    "null": true,
+    "package": true,
+    "private": true,
+    "protected": true,
+    "public": true,
+    "return": true,
+    "short": true,
+    "static": true,
+    "super": false,
+    "switch": true,
+    "synchronized": true,
+    "this": true,
+    "throw": true,
+    "throws": true,
+    "transient": true,
+    "true": true,
+    "try": true,
+    "typeof": true,
+    "use": true,
+    "var": true,
+    "void": true,
+    "volatile": true,
+    "while": true,
+    "with": true
+};
+
+/**
+ * Fix reserved words
+ * 
+ * @param {string} name
+ */
+function fixReservedWords(name) {
+    if (reservedWords_[name] !== true) {
+        return name;
+    }
+    return name + "_$rw$";
+}
 
 var reservedNames_ = {
     "__defineGetter__": true,
@@ -1379,6 +1379,7 @@ Compiler.prototype.cfromimport = function (s) {
     var n = s.names.length;
     var names = [];
     for (i = 0; i < n; ++i) {
+        s.names[i].name.v = fixReservedWords(s.names[i].name.v);
         names[i] = Sk.fixReservedWords(s.names[i].name["$r"]().v);
     }
     out("$ret = Sk.builtin.__import__(", s.module["$r"]().v, ",$gbl,$loc,[", names, "]);");
@@ -1397,7 +1398,7 @@ Compiler.prototype.cfromimport = function (s) {
         }
 
         //out("print(\"getting Sk.abstr.gattr(", mod, ",", alias.name["$r"]().v, ")\");");
-        got = this._gr("item", "Sk.abstr.gattr(", mod, ",", Sk.fixReservedWords(alias.name["$r"]().v), ")");
+        got = this._gr("item", "Sk.abstr.gattr(", mod, ",", alias.name["$r"]().v, ")");
         //out("print('got');");
         storeName = alias.name;
         if (alias.asname) {
@@ -2113,7 +2114,7 @@ Compiler.prototype.nameop = function (name, ctx, dataToStore) {
     }
 
     // have to do this after looking it up in the scope
-    mangled = Sk.fixReservedWords(mangled);
+    mangled = fixReservedWords(mangled);
 
     //print("mangled", mangled);
     // TODO TODO TODO todo; import * at global scope failing here
@@ -2244,7 +2245,7 @@ Compiler.prototype.exitScope = function () {
     if (prev.name.v !== "<module>") {// todo; hacky
         mangled = prev.name["$r"]().v;
         mangled = mangled.substring(1, mangled.length - 1);
-        mangled = Sk.fixReservedWords(mangled);
+        mangled = fixReservedWords(mangled);
         mangled = fixReservedNames(mangled);
         out(prev.scopename, ".co_name=new Sk.builtins['str']('", mangled, "');");
     }
@@ -2378,4 +2379,3 @@ Sk.resetCompiler = function () {
 };
 
 goog.exportSymbol("Sk.resetCompiler", Sk.resetCompiler);
-goog.exportSymbol("Sk.fixReservedWords", Sk.fixReservedWords);

--- a/src/compile.js
+++ b/src/compile.js
@@ -1379,7 +1379,7 @@ Compiler.prototype.cfromimport = function (s) {
     var n = s.names.length;
     var names = [];
     for (i = 0; i < n; ++i) {
-        names[i] = s.names[i].name["$r"]().v;
+        names[i] = Sk.fixReservedWords(s.names[i].name["$r"]().v);
     }
     out("$ret = Sk.builtin.__import__(", s.module["$r"]().v, ",$gbl,$loc,[", names, "]);");
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -72,7 +72,7 @@ var reservedWords_ = {
 /**
  * Fix reserved words
  * 
- * @param {string}
+ * @param {string} name
  */
 Sk.fixReservedWords = function fixReservedWords(name) {
     if (reservedWords_[name] !== true) {
@@ -1397,7 +1397,7 @@ Compiler.prototype.cfromimport = function (s) {
         }
 
         //out("print(\"getting Sk.abstr.gattr(", mod, ",", alias.name["$r"]().v, ")\");");
-        got = this._gr("item", "Sk.abstr.gattr(", mod, ",", alias.name["$r"]().v, ")");
+        got = this._gr("item", "Sk.abstr.gattr(", mod, ",", Sk.fixReservedWords(alias.name["$r"]().v), ")");
         //out("print('got');");
         storeName = alias.name;
         if (alias.asname) {

--- a/src/compile.js
+++ b/src/compile.js
@@ -1374,6 +1374,7 @@ Compiler.prototype.cfromimport = function (s) {
     var storeName;
     var got;
     var alias;
+    var aliasOut;
     var mod;
     var i;
     var n = s.names.length;

--- a/src/compile.js
+++ b/src/compile.js
@@ -712,7 +712,7 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
             mangled = e.attr["$r"]().v;
             mangled = mangled.substring(1, mangled.length - 1);
             mangled = mangleName(this.u.private_, new Sk.builtin.str(mangled)).v;
-            mangled = Sk.fixReservedWords(mangled);
+            mangled = fixReservedWords(mangled);
             mangled = fixReservedNames(mangled);
             switch (e.ctx) {
                 case AugLoad:
@@ -1380,7 +1380,7 @@ Compiler.prototype.cfromimport = function (s) {
     var names = [];
     for (i = 0; i < n; ++i) {
         s.names[i].name.v = fixReservedWords(s.names[i].name.v);
-        names[i] = Sk.fixReservedWords(s.names[i].name["$r"]().v);
+        names[i] = s.names[i].name["$r"]().v;
     }
     out("$ret = Sk.builtin.__import__(", s.module["$r"]().v, ",$gbl,$loc,[", names, "]);");
 

--- a/src/compile.js
+++ b/src/compile.js
@@ -1379,8 +1379,7 @@ Compiler.prototype.cfromimport = function (s) {
     var n = s.names.length;
     var names = [];
     for (i = 0; i < n; ++i) {
-        s.names[i].name.v = fixReservedWords(s.names[i].name.v);
-        names[i] = s.names[i].name["$r"]().v;
+        names[i] = "'" + fixReservedWords(s.names[i].name.v) + "'";
     }
     out("$ret = Sk.builtin.__import__(", s.module["$r"]().v, ",$gbl,$loc,[", names, "]);");
 
@@ -1391,6 +1390,7 @@ Compiler.prototype.cfromimport = function (s) {
     mod = this._gr("module", "$ret");
     for (i = 0; i < n; ++i) {
         alias = s.names[i];
+        aliasOut = fixReservedWords(alias.name.v);
         if (i === 0 && alias.name.v === "*") {
             goog.asserts.assert(n === 1);
             out("Sk.importStar(", mod, ",$loc, $gbl);");
@@ -1398,7 +1398,7 @@ Compiler.prototype.cfromimport = function (s) {
         }
 
         //out("print(\"getting Sk.abstr.gattr(", mod, ",", alias.name["$r"]().v, ")\");");
-        got = this._gr("item", "Sk.abstr.gattr(", mod, ",", alias.name["$r"]().v, ")");
+        got = this._gr("item", "Sk.abstr.gattr(", mod, ",", aliasOut, ")");
         //out("print('got');");
         storeName = alias.name;
         if (alias.asname) {

--- a/src/compile.js
+++ b/src/compile.js
@@ -1391,7 +1391,7 @@ Compiler.prototype.cfromimport = function (s) {
     mod = this._gr("module", "$ret");
     for (i = 0; i < n; ++i) {
         alias = s.names[i];
-        aliasOut = fixReservedWords(alias.name.v);
+        aliasOut = "'" + fixReservedWords(alias.name.v) + "'";
         if (i === 0 && alias.name.v === "*") {
             goog.asserts.assert(n === 1);
             out("Sk.importStar(", mod, ",$loc, $gbl);");

--- a/src/compile.js
+++ b/src/compile.js
@@ -3,6 +3,84 @@ var out;
 
 Sk.gensymcount = 0;
 
+var reservedWords_ = {
+    "abstract": true,
+    "as": true,
+    "boolean": true,
+    "break": true,
+    "byte": true,
+    "case": true,
+    "catch": true,
+    "char": true,
+    "class": true,
+    "continue": true,
+    "const": true,
+    "debugger": true,
+    "default": true,
+    "delete": true,
+    "do": true,
+    "double": true,
+    "else": true,
+    "enum": true,
+    "export": true,
+    "extends": true,
+    "false": true,
+    "final": true,
+    "finally": true,
+    "float": true,
+    "for": true,
+    "function": true,
+    "goto": true,
+    "if": true,
+    "implements": true,
+    "import": true,
+    "in": true,
+    "instanceof": true,
+    "int": true,
+    "interface": true,
+    "is": true,
+    "long": true,
+    "namespace": true,
+    "native": true,
+    "new": true,
+    "null": true,
+    "package": true,
+    "private": true,
+    "protected": true,
+    "public": true,
+    "return": true,
+    "short": true,
+    "static": true,
+    "super": false,
+    "switch": true,
+    "synchronized": true,
+    "this": true,
+    "throw": true,
+    "throws": true,
+    "transient": true,
+    "true": true,
+    "try": true,
+    "typeof": true,
+    "use": true,
+    "var": true,
+    "void": true,
+    "volatile": true,
+    "while": true,
+    "with": true
+};
+
+/**
+ * Fix reserved words
+ * 
+ * @param {string}
+ */
+Sk.fixReservedWords = function fixReservedWords(name) {
+    if (reservedWords_[name] !== true) {
+        return name;
+    }
+    return name + "_$rw$";
+}
+
 /**
  * @constructor
  * @param {string} filename
@@ -121,79 +199,6 @@ Compiler.prototype.gensym = function (hint) {
 Compiler.prototype.niceName = function (roughName) {
     return this.gensym(roughName.replace("<", "").replace(">", "").replace(" ", "_"));
 };
-
-var reservedWords_ = {
-    "abstract": true,
-    "as": true,
-    "boolean": true,
-    "break": true,
-    "byte": true,
-    "case": true,
-    "catch": true,
-    "char": true,
-    "class": true,
-    "continue": true,
-    "const": true,
-    "debugger": true,
-    "default": true,
-    "delete": true,
-    "do": true,
-    "double": true,
-    "else": true,
-    "enum": true,
-    "export": true,
-    "extends": true,
-    "false": true,
-    "final": true,
-    "finally": true,
-    "float": true,
-    "for": true,
-    "function": true,
-    "goto": true,
-    "if": true,
-    "implements": true,
-    "import": true,
-    "in": true,
-    "instanceof": true,
-    "int": true,
-    "interface": true,
-    "is": true,
-    "long": true,
-    "namespace": true,
-    "native": true,
-    "new": true,
-    "null": true,
-    "package": true,
-    "private": true,
-    "protected": true,
-    "public": true,
-    "return": true,
-    "short": true,
-    "static": true,
-    "super": false,
-    "switch": true,
-    "synchronized": true,
-    "this": true,
-    "throw": true,
-    "throws": true,
-    "transient": true,
-    "true": true,
-    "try": true,
-    "typeof": true,
-    "use": true,
-    "var": true,
-    "void": true,
-    "volatile": true,
-    "while": true,
-    "with": true
-};
-
-function fixReservedWords (name) {
-    if (reservedWords_[name] !== true) {
-        return name;
-    }
-    return name + "_$rw$";
-}
 
 var reservedNames_ = {
     "__defineGetter__": true,
@@ -707,7 +712,7 @@ Compiler.prototype.vexpr = function (e, data, augvar, augsubs) {
             mangled = e.attr["$r"]().v;
             mangled = mangled.substring(1, mangled.length - 1);
             mangled = mangleName(this.u.private_, new Sk.builtin.str(mangled)).v;
-            mangled = fixReservedWords(mangled);
+            mangled = Sk.fixReservedWords(mangled);
             mangled = fixReservedNames(mangled);
             switch (e.ctx) {
                 case AugLoad:
@@ -2108,7 +2113,7 @@ Compiler.prototype.nameop = function (name, ctx, dataToStore) {
     }
 
     // have to do this after looking it up in the scope
-    mangled = fixReservedWords(mangled);
+    mangled = Sk.fixReservedWords(mangled);
 
     //print("mangled", mangled);
     // TODO TODO TODO todo; import * at global scope failing here
@@ -2239,7 +2244,7 @@ Compiler.prototype.exitScope = function () {
     if (prev.name.v !== "<module>") {// todo; hacky
         mangled = prev.name["$r"]().v;
         mangled = mangled.substring(1, mangled.length - 1);
-        mangled = fixReservedWords(mangled);
+        mangled = Sk.fixReservedWords(mangled);
         mangled = fixReservedNames(mangled);
         out(prev.scopename, ".co_name=new Sk.builtins['str']('", mangled, "');");
     }
@@ -2373,3 +2378,4 @@ Sk.resetCompiler = function () {
 };
 
 goog.exportSymbol("Sk.resetCompiler", Sk.resetCompiler);
+goog.exportSymbol("Sk.fixReservedWords", Sk.fixReservedWords);

--- a/src/ffi.js
+++ b/src/ffi.js
@@ -84,6 +84,8 @@ Sk.ffi.remapToJs = function (obj) {
         return Sk.builtin.asnum$(obj);
     } else if (typeof obj === "number" || typeof obj === "boolean") {
         return obj;
+    } else if (obj === undefined) {
+        return undefined;
     } else {
         return obj.v;
     }

--- a/src/import.js
+++ b/src/import.js
@@ -601,7 +601,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
             var foundFromName; // Contains the sysmodules[name] the current item from the fromList
 
             for (i = 0; i < fromlist.length; i++) {
-                fromName = Sk.fixReservedWords(fromlist[i]);
+                fromName = fromlist[i];
 
                 foundFromName = false;
                 found = Sk.sysmodules.sq$contains(name); // Check if "name" is inside sysmodules

--- a/src/import.js
+++ b/src/import.js
@@ -567,10 +567,12 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
     // a Python language module.  for some reason, __name__ gets overwritten.
     var saveSk = Sk.globals;
 
+    var file = Sk.ffi.remapToJs(locals["__file__"]);
+
     var currentDir =
-        locals["__file__"] === undefined ?
+        file === undefined ?
             undefined :
-            locals["__file__"].v.substring(0, locals["__file__"].v.lastIndexOf("/"));
+            file.substring(0, file.lastIndexOf("/"));
 
     var ret = Sk.importModuleInternal_(name, undefined, undefined, undefined, true, currentDir);
 

--- a/src/import.js
+++ b/src/import.js
@@ -601,7 +601,7 @@ Sk.builtin.__import__ = function (name, globals, locals, fromlist) {
             var foundFromName; // Contains the sysmodules[name] the current item from the fromList
 
             for (i = 0; i < fromlist.length; i++) {
-                fromName = fromlist[i];
+                fromName = Sk.fixReservedWords(fromlist[i]);
 
                 foundFromName = false;
                 found = Sk.sysmodules.sq$contains(name); // Check if "name" is inside sysmodules


### PR DESCRIPTION
the `var` variable didn't get mangled I first added the mangling in import.js but then I found out I could do it in compile.js.

After a bit of fiddling about I got the last example to work too:

http://albertjan-dev.trinket.io/python/d16a129689