### PR TITLE
Sk.misceval.callsim this Screen constructor

### DIFF
--- a/src/lib/turtle.js
+++ b/src/lib/turtle.js
@@ -1100,7 +1100,7 @@ function generateTurtleModule(_target) {
         proto.$ondrag.keywordArgs = ["btn","add"];
 
         proto.$getscreen = function() {
-            return _module.Screen();
+            return Sk.misceval.callsim(_module.Screen);
         };
         proto.$getscreen.isSk = true;
 


### PR DESCRIPTION
See: http://albertjan-dev.trinket.io/python/909b09690a 

it's fixed on my branch I branched trinket of develop and skulpt of trinket-master... 