### PR TITLE
Fix/fabs co_name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "skulpt",
-  "version": "0.11.1.27",
+  "version": "0.11.1.28",
   "main": [ "./skulpt.js", "./skulpt-stdlib.js" ],
   "description": "Skulpt is a Javascript implementation of the Python programming language",
   "repository": {

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -484,9 +484,9 @@ Sk.builtin.abs = function abs (x) {
 
 // fabs belongs in the math module but has been a Skulpt builtin since 41665a97d (2012).
 // Left in for backwards compatibility for now
-Sk.builtin.fabs = function fabs(x) { 
+Sk.builtin.fabs = function fabs(x) {
     return Sk.builtin.abs(x);
-}
+};
 
 Sk.builtin.ord = function ord (x) {
     Sk.builtin.pyCheckArgs("ord", arguments, 1, 1);

--- a/src/builtin.js
+++ b/src/builtin.js
@@ -484,7 +484,9 @@ Sk.builtin.abs = function abs (x) {
 
 // fabs belongs in the math module but has been a Skulpt builtin since 41665a97d (2012).
 // Left in for backwards compatibility for now
-Sk.builtin.fabs = Sk.builtin.abs;
+Sk.builtin.fabs = function fabs(x) { 
+    return Sk.builtin.abs(x);
+}
 
 Sk.builtin.ord = function ord (x) {
     Sk.builtin.pyCheckArgs("ord", arguments, 1, 1);


### PR DESCRIPTION
Sorry @eah13 I should have stressed this more yesterday, but fabs needs to be a seperate function because otherwise the `co_name` of `"abs"` becomes `"fabs"` causing `abs` not to be recognised as an internal function.

:smile: